### PR TITLE
Replace TAB to 4 spaces

### DIFF
--- a/test.py
+++ b/test.py
@@ -54,7 +54,7 @@ def test():
             # Get model name
             mname = open(hp.logdir + '/checkpoint', 'r').read().split('"')[1] # model name
             
-	    if not os.path.exists('results'): os.mkdir('results')
+            if not os.path.exists('results'): os.mkdir('results')
             fout = 'results/{}.txt'.format(mname)
             import copy
             _preds = copy.copy(x)


### PR DESCRIPTION
When I run `python test.py`, it has crashed.
So I fixed to replace TAB to 4 spaces.

```
$ python test.py
File "test.py", line 57
    if not os.path.exists('results'): os.mkdir('results')
                                                        ^
TabError: inconsistent use of tabs and spaces in indentation
```

@Kyubyong 